### PR TITLE
Generalize, simplify, and document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 git.h
 .DS_Store
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,13 @@
 cmake_minimum_required(VERSION 3.2)
 
-# Pull in the code to watch git.
-# This automatically defines the AlwaysCheckGit target.
+# Define the two required variables before including
+# the source code for watching a git repository.
+set(PRE_CONFIGURE_FILE "git.h.in")
+set(POST_CONFIGURE_FILE "git.h")
 include(git_watcher.cmake)
 
 # Create a demo executable.
 # Note that one of the dependencies is the configured git header.
-add_executable(demo git.h main.cc)
+add_executable(demo ${POST_CONFIGURE_FILE} main.cc)
 
-# Indicate that the demo depends on the AlwaysCheckGit target.
-# Whenever we try to build demo, we'll first check the repo for any changes.
-# If any changes were made, then git.h will be updated.
-# Then demo will be rebuilt with that updated header.
-add_dependencies(demo AlwaysCheckGit)
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is a demo project that shows how to embed up-to-date
 versioning information into a C/C++ application via CMake.
 
 ## A "why does this matter" use case
-We're continuously shipping prebuild binaries for an
+We're continuously shipping prebuilt binaries for an
 application. A user discovers a bug and files a bug report.
 By embedding up-to-date versioning information, the user
 can include this in their report, e.g.:
@@ -22,8 +22,9 @@ searched far and wide for existing solutions. Each solution I found fell
 into one of two categories:
 
 - Write the commit ID to the header at configure time (e.g. `cmake <source_dir>`).
-  This was a poor solution- any changes (e.g. `git commit -am "Changed X"`)
-  aren't reflected in the header.
+  This works well for automated build processes (e.g. check-in code and build artifacts).
+  However, it has one weakness: any changes made after running `cmake`
+  (e.g. `git commit -am "Changed X"`) aren't reflected in the header.
 
 - Every time a build is started (e.g. `make`), write the commit ID to a header.
   While this was better than the above, it had one major drawback:
@@ -41,7 +42,7 @@ reconfigure the header and CMake rebuilds any downstream dependencies.
 2. Configure the project (`mkdir build && cd build && cmake ..`).
 3. Build it (`make`).
 3. Run `./demo`- note the SHA1.
-4. Build it again- note that nothing is recompiled (sweet!).
+4. Build it again (`make`)- note that nothing is recompiled (sweet!).
 5. Edit README.md, then build and run the demo- note that the demo now reports that the HEAD is dirty.
 6. Commit something, then build and run the demo- note that the SHA1 has changed.
 
@@ -64,4 +65,4 @@ const std::string kGitSHA = "@GIT_SHA1@";
 const std::string kGitSHA = "1234567";
 ```
 
-Thus, only `git.cc` need to be recompiled whenever a commit is made.
+Thus, only the `git.cc` source file needs to be recompiled whenever a commit is made.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ reconfigure the header and CMake rebuilds any downstream dependencies.
 6. Commit something, then build and run the demo- note that the SHA1 has changed.
 
 ## Tip: how to avoid unnecessary recompilations
-If you're worred about lengthy recompilations, then **don't** place the
+If you're worried about lengthy recompilations, then **don't** place the
 versioning information in a header that is then included in _every_ source
 file. Doing so would defeat the purpose of partial rebuilds.
 I shudder to think of how much time would be wasted.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ searched far and wide for existing solutions. Each solution I found fell
 into one of two categories:
 
 - Write the commit ID to the header at configure time (e.g. `cmake <source_dir>`).
-  This was a poor solution- any changes (e.g. `git commit -am "Changed X"`) 
+  This was a poor solution- any changes (e.g. `git commit -am "Changed X"`)
   aren't reflected in the header.
 
 - Every time a build is started (e.g. `make`), write the commit ID to a header.

--- a/git.h.in
+++ b/git.h.in
@@ -9,5 +9,3 @@
 
 // Whether or not there were uncommited changes present.
 #define GIT_IS_DIRTY @GIT_IS_DIRTY@
-
-

--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -13,7 +13,7 @@
 #   - This script was designed similar to a Python application
 #     with a Main() function. I wanted to keep it compact to
 #     simplify "copy + paste" usage.
-# 
+#
 #   - This script is made to operate in two scopes:
 #       1. Configure time scope (when build files are created).
 #       2. Build time scope (called via CMake -P)
@@ -62,60 +62,60 @@ endfunction()
 #   _working_dir (in)  string; the directory from which git commands will be ran.
 #   _hashvar     (out) string; the SHA1 hash for HEAD.
 #   _dirty       (out) boolean; whether or not there are uncommitted changes.
-#   _success     (out) boolean; whether or not both 
+#   _success     (out) boolean; whether or not both
 function(GetGitState _working_dir _hashvar _dirty _success)
 
-	# Initialize our returns.
-	set(${_hashvar} "GIT-NOTFOUND" PARENT_SCOPE)
-	set(${_dirty} "false" PARENT_SCOPE)
-	set(${_success} "false" PARENT_SCOPE)
+    # Initialize our returns.
+    set(${_hashvar} "GIT-NOTFOUND" PARENT_SCOPE)
+    set(${_dirty} "false" PARENT_SCOPE)
+    set(${_success} "false" PARENT_SCOPE)
 
-	# Find git.
-	if(NOT GIT_FOUND)
-		find_package(Git QUIET)
-	endif()
-	if(NOT GIT_FOUND)
-		return()
-	endif()
+    # Find git.
+    if(NOT GIT_FOUND)
+        find_package(Git QUIET)
+    endif()
+    if(NOT GIT_FOUND)
+        return()
+    endif()
 
-	# Get the hash for HEAD.
-	execute_process(COMMAND
-		"${GIT_EXECUTABLE}" rev-parse --verify HEAD
-		WORKING_DIRECTORY "${_working_dir}"
-		RESULT_VARIABLE res
-		OUTPUT_VARIABLE hash
-		ERROR_QUIET
-		OUTPUT_STRIP_TRAILING_WHITESPACE)
-	if(NOT res EQUAL 0)
+    # Get the hash for HEAD.
+    execute_process(COMMAND
+        "${GIT_EXECUTABLE}" rev-parse --verify HEAD
+        WORKING_DIRECTORY "${_working_dir}"
+        RESULT_VARIABLE res
+        OUTPUT_VARIABLE hash
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT res EQUAL 0)
         # The git command failed.
-		return()
-	endif()
+        return()
+    endif()
 
     # Record the SHA1 hash for HEAD.
     set(${_hashvar} "${hash}" PARENT_SCOPE)
 
-	# Get whether or not the working tree is dirty.
-	execute_process(COMMAND
-		"${GIT_EXECUTABLE}" status --porcelain
-		WORKING_DIRECTORY "${_working_dir}"
-		RESULT_VARIABLE res
-		OUTPUT_VARIABLE out
-		ERROR_QUIET
-		OUTPUT_STRIP_TRAILING_WHITESPACE)
-	if(NOT res EQUAL 0)
-		# The git command failed.
-		return()
-	endif()
+    # Get whether or not the working tree is dirty.
+    execute_process(COMMAND
+        "${GIT_EXECUTABLE}" status --porcelain
+        WORKING_DIRECTORY "${_working_dir}"
+        RESULT_VARIABLE res
+        OUTPUT_VARIABLE out
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT res EQUAL 0)
+        # The git command failed.
+        return()
+    endif()
 
-	# If there were uncommitted changes, mark it as dirty.
-	if (NOT "${out}" STREQUAL "")
-		set(${_dirty} "true" PARENT_SCOPE)
-	else()
-		set(${_dirty} "false" PARENT_SCOPE)
-	endif()
+    # If there were uncommitted changes, mark it as dirty.
+    if (NOT "${out}" STREQUAL "")
+        set(${_dirty} "true" PARENT_SCOPE)
+    else()
+        set(${_dirty} "false" PARENT_SCOPE)
+    endif()
 
     # We got this far, so git must have cooperated.
-	set(${_success} "true" PARENT_SCOPE)
+    set(${_success} "true" PARENT_SCOPE)
 endfunction()
 
 
@@ -148,7 +148,7 @@ function(MonitorGit)
     add_custom_target(AlwaysCheckGit
         DEPENDS ${pre_configure_file}
         BYPRODUCTS ${post_configure_file}
-        COMMAND 
+        COMMAND
             ${CMAKE_COMMAND}
             -DGIT_FUNCTION=DoMonitoring
             -DGIT_WORKING_DIR=${CMAKE_CURRENT_SOURCE_DIR}

--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -1,8 +1,8 @@
 # git_watcher.cmake
 #
-# This file defines the functions and targets needed to keep a
-# watch on the state of the git repo. If the state changes, a
-# header is reconfigured.
+# This file defines the functions and targets needed to monitor
+# the state of a git repo. If the state changes (e.g. a commit is added),
+# then a header gets reconfigured.
 #
 # Customization tip:
 #   - You should only need to edit the paths to the pre and

--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -14,11 +14,11 @@
 #     with a Main() function. I wanted to keep it compact to
 #     simplify "copy + paste" usage.
 #
-#   - This script is made to operate in two scopes:
-#       1. Configure time scope (when build files are created).
-#       2. Build time scope (called via CMake -P)
+#   - This script is made to operate in two CMake contexts:
+#       1. Configure time context (when build files are created).
+#       2. Build time context (called via CMake -P)
 #     If you see something odd (e.g. the NOT DEFINED clauses),
-#     consider that it can run in one of two scopes.
+#     consider that it can run in one of two contexts.
 
 if(NOT DEFINED post_configure_file)
     set(post_configure_file "${CMAKE_CURRENT_SOURCE_DIR}/git.h")

--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -150,7 +150,7 @@ function(MonitorGit)
         BYPRODUCTS ${post_configure_file}
         COMMAND
             ${CMAKE_COMMAND}
-            -DGIT_FUNCTION=DoMonitoring
+            -D_BUILD_TIME_CHECK_GIT=TRUE
             -DGIT_WORKING_DIR=${CMAKE_CURRENT_SOURCE_DIR}
             -Dpre_configure_file=${pre_configure_file}
             -Dpost_configure_file=${post_configure_file}
@@ -192,7 +192,7 @@ endfunction()
 # Description: primary entry-point to the script. Functions are selected based
 #              on the GIT_FUNCTION variable.
 function(Main)
-    if(GIT_FUNCTION STREQUAL DoMonitoring)
+    if(_BUILD_TIME_CHECK_GIT)
         # Check if the repo has changed.
         # If so, run the change action.
         CheckGit("${GIT_WORKING_DIR}" changed)
@@ -203,6 +203,7 @@ function(Main)
             message(STATUS "Checking git... no change.")
         endif()
     else()
+        # >> Executes at configure time.
         # Start monitoring git.
         # This should only ever be run once when the module is imported.
         # Behind the scenes, all this does is setup a custom target.


### PR DESCRIPTION
Revisiting this two years later with a fresh set of eyes revealed some opportunities to simplify and streamline the module. Two major changes stand out:

1. The repository state is now passed around as a list - making it easier to adapt the module to accept additional state variables (e.g. commit author).
2. The usage of the script was simplified by removing the need to call `add_dependencies` and by extracting the pre/post-configure file paths into required variables.

(tested via CMake 3.10.2 using both Makefile and Ninja generators)