### PR TITLE
Added required dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,5 +9,4 @@ include(git_watcher.cmake)
 # Create a demo executable.
 # Note that one of the dependencies is the configured git header.
 add_executable(demo ${POST_CONFIGURE_FILE} main.cc)
-
-
+add_dependencies( demo check_git_repository )


### PR DESCRIPTION
Hi Andrew, this project is awesome. I've wanting to write something like that for a while. The code is also very elegant and easy to integrate in other projects.

Only one glitch on my system (macos 10.14, CMake 3.13.3 using makefile generator): the git.h file is not generated unless I explicitly add a dependency between the executable and check_git_repository custom target.