### PR TITLE
Add support for version numbers parsed from git tags

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.2)
 # the source code for watching a git repository.
 set(PRE_CONFIGURE_FILE "git.h.in")
 set(POST_CONFIGURE_FILE "git.h")
+set(VERSION_TAG_PREFIX_REGEX "^version-")
 include(git_watcher.cmake)
 
 # Create a demo executable.

--- a/demo/git.h.in
+++ b/demo/git.h.in
@@ -9,3 +9,15 @@
 
 // Whether or not there were uncommited changes present.
 #define GIT_IS_DIRTY @GIT_IS_DIRTY@
+
+// The next git tag that was found for the HEAD of the repo.
+#define GIT_TAG "@GIT_TAG@"
+
+// Number of additional commits between the git tag and HEAD (0 = exact match)
+#define GIT_ADDITIONAL_COMMITS @GIT_ADDITIONAL_COMMITS@
+
+// Version number that got extracted from the git tag
+#define VERSION_MAJOR @VERSION_MAJOR@
+#define VERSION_MINOR @VERSION_MINOR@
+#define VERSION_PATCH @VERSION_PATCH@
+#define VERSION "@VERSION@"

--- a/demo/main.cc
+++ b/demo/main.cc
@@ -6,7 +6,11 @@
 int main() {
     // Demo that our macros work.
     if(GIT_RETRIEVED_STATE) {
-        std::cout << "INFO: " << GIT_HEAD_SHA1 << std::endl;
+        std::cout << "INFO: ";
+        if(VERSION_MAJOR != -1) std::cout << VERSION_MAJOR;
+        if(VERSION_MINOR != -1) std::cout << "." << VERSION_MINOR;
+        if(VERSION_PATCH != -1) std::cout << "." << VERSION_PATCH;
+        std::cout << " (" << GIT_HEAD_SHA1 << ")"<< std::endl;
         if(GIT_IS_DIRTY) std::cerr << "WARN: there were uncommitted changes." << std::endl;
         return EXIT_SUCCESS;
     }

--- a/functional_tests/test_no_tags.sh
+++ b/functional_tests/test_no_tags.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Purpose:
+# Test how the demo performs when no git tag is present. This test was added
+# because git describe will fallback to a hash without prefix if that happens
+# due to its --always option.
+
+# Load utilities.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/util.sh
+
+VERSION_PREFIX='version-'
+VERSION='7.3.17'
+
+# Create git history
+set -e
+cd $src
+git init
+git add .
+git commit -am "Initial commit."
+
+# Build the project
+set -e
+cd $build
+cmake -G "$TEST_GENERATOR" $src
+cmake --build . --target demo
+
+# Run the demo.
+# It should report EXIT_SUCCESS because git history was found.
+set +e
+./demo &> output.txt
+assert "$? -eq 0" $LINENO
+
+# Check that the git commit matches what git reports.
+set -e
+truth=$(cd $src && git rev-parse --verify HEAD)
+if ! grep -q $truth output.txt; then
+    # Commit ID wasn't found.
+    echo "Demo didn't print the correct commit."
+    assert "1 -eq 0" $LINENO
+fi

--- a/functional_tests/test_version.sh
+++ b/functional_tests/test_version.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Purpose:
+# Test how the demo performs when parsing the version number from a git tag.
+
+# Load utilities.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/util.sh
+
+VERSION_PREFIX='version-'
+VERSION='7.3.17'
+
+# Create git history
+set -e
+cd $src
+git init
+git add .
+git commit -am "Initial commit."
+git tag "${VERSION_PREFIX}${VERSION}"
+# Build the project
+set -e
+cd $build
+cmake -G "$TEST_GENERATOR" $src
+cmake --build . --target demo
+
+# Run the demo.
+# It should report EXIT_SUCCESS because git history was found.
+set +e
+./demo &> output.txt
+assert "$? -eq 0" $LINENO
+
+# Check that the version matches the git tag.
+set -e
+truth="${VERSION}"
+if ! grep -q $truth output.txt; then
+    # Version string wasn't found.
+    echo "Demo didn't print the correct version."
+    assert "1 -eq 0" $LINENO
+fi


### PR DESCRIPTION
Most projects use [some kind of version number](https://semver.org/) stored within a git tag name to identify a release instead of using the plain git hash. This pull request adds support for version number tags that contain up to three component (e.g. `v7.3` or `v7.3.17`).

It uses [git describe](https://git-scm.com/docs/git-describe) to fetch all the information with one git call, mostly because I was not able find a simple alternative to fill the `GIT_TAG` and `GIT_ADDITIONAL_COMMITS` values. The downside of this is that I had to do some quirky parsing of the human readable output of git describe that, for instance, [will vary in the absence of any tags](https://git-scm.com/docs/git-describe#Documentation/git-describe.txt---always).