### PR TITLE
Store the state hash instead of the raw state string.

### DIFF
--- a/tests/test_no_change_means_no_rebuild.sh
+++ b/tests/test_no_change_means_no_rebuild.sh
@@ -34,7 +34,7 @@ fi
 
 # Watch the git-state file and make sure it doesn't change
 # when we try to rebuild the project.
-state_file="$build/git-state"
+state_file="$build/git-state-hash"
 demo_file="$build/demo"
 last_touched_state="$(stat -c %y $state_file)"
 last_touched_exe="$(stat -c %y $demo_file)"


### PR DESCRIPTION
This module depends on the following behavior:
```python
state = check()
old_state = load_from_disk()
if state != old_state:
    save_to_disk(state)
    update_header(state)
```
The content of the state file was just a concatenation of all the state variables. This PR replaces that state with a hash. The hash is stored to disk, and the individual state variables are passed via `ENV`. This simplifies the steps that go into extending the script to track additional git metadata.