### PR TITLE
Regenerate header after `make clean`

### DIFF
--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -242,7 +242,9 @@ function(SetupGitMonitoring)
     add_custom_target(check_git
         ALL
         DEPENDS ${PRE_CONFIGURE_FILE}
-        BYPRODUCTS ${POST_CONFIGURE_FILE}
+        BYPRODUCTS
+            ${POST_CONFIGURE_FILE}
+            ${GIT_STATE_FILE}
         COMMENT "Checking the git repository for changes..."
         COMMAND
             ${CMAKE_COMMAND}

--- a/tests/test_make_clean.sh
+++ b/tests/test_make_clean.sh
@@ -3,11 +3,28 @@
 # Issue #9:
 # Verify that the header is regenerated after a make clean.
 # https://github.com/andrew-hardin/cmake-git-version-tracking/issues/9
-
+#
+# For additional context, see this issue:
+# https://gitlab.kitware.com/cmake/cmake/issues/18300
+#
+# Depending on which version of CMake you're using, the makefile
+# generator may or may-not remove byproducts of custom targets.
 
 # Load utilities.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $DIR/util.sh
+
+# Don't run the test if we're pre-3.13.
+version=$(cmake --version | head -n 1)
+version=${version##* }
+major=${version%%.*}
+patch=${version##*.}
+minor=${version##$major.}
+minor=${minor%%.$patch}
+if [[ $major -lt 3 || ( $major -eq 3  &&  $minor -lt 13 ) ]]; then
+    echo "CMake $version doesn't remove makefile byproducts- skipping test"
+    exit 0
+fi
 
 # Create git history
 set -e
@@ -27,7 +44,8 @@ cmake --build . --target demo
 assert "-f $src/git.h" $LINENO
 assert "-f $build/git-state-hash" $LINENO
 
-# Make clean should scrub both these files.
+# Make followed by clean should scrub both these files.
+make
 make clean
 assert "! -f $src/git.h" $LINENO
 assert "! -f $build/git-state-hash" $LINENO

--- a/tests/test_make_clean.sh
+++ b/tests/test_make_clean.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Issue #9:
+# Verify that the header is regenerated after a make clean.
+# https://github.com/andrew-hardin/cmake-git-version-tracking/issues/9
+
+
+# Load utilities.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/util.sh
+
+# Create git history
+set -e
+cd $src
+git init
+git add .
+git commit -am "Initial commit."
+
+# Build the project
+set -e
+cd $build
+cmake -G "$TEST_GENERATOR" $src
+cmake --build . --target demo
+
+# The configured header should exist.
+# The git-state file should exist.
+assert "-f $src/git.h" $LINENO
+assert "-f $build/git-state-hash" $LINENO
+
+# Make clean should scrub both these files.
+make clean
+assert "! -f $src/git.h" $LINENO
+assert "! -f $build/git-state-hash" $LINENO
+
+# We should generate them again after calling make.
+make
+assert "-f $src/git.h" $LINENO
+assert "-f $build/git-state-hash" $LINENO


### PR DESCRIPTION
This addresses the specific `make clean` issue described in #9.
Another PR will address the generic case of "regenerate the header if it ever goes missing."