### PR TITLE
Handle the general case where the header goes missing.

### DIFF
--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -265,7 +265,7 @@ function(Main)
         # Check if the repo has changed.
         # If so, run the change action.
         CheckGit("${GIT_WORKING_DIR}" changed)
-        if(changed)
+        if(changed OR NOT EXISTS "${POST_CONFIGURE_FILE}")
             GitStateChangedAction()
         endif()
     else()

--- a/tests/test_missing_header.sh
+++ b/tests/test_missing_header.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Purpose:
+# Test that we can regenerate the header if it goes missing.
+# See issue #9.
+
+# Load utilities.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/util.sh
+
+# Create git history
+set -e
+cd $src
+git init
+git add .
+git commit -am "Initial commit."
+
+# Build the project
+set -e
+cd $build
+cmake -G "$TEST_GENERATOR" $src
+cmake --build . --target demo
+
+# Nuke the header, then check that it gets generated automatically
+# when we try to build the project again.
+rm $src/git.h
+make
+assert "-f $src/git.h" $LINENO


### PR DESCRIPTION
This resolves the general case described in #9. The script now regenerates the header if the git-state changes _or_ the header is missing.