### PR TITLE
Replace relative symlinks with different include path.

### DIFF
--- a/better-example/CMakeLists.txt
+++ b/better-example/CMakeLists.txt
@@ -5,7 +5,7 @@ project(BetterExample)
 # the source code for watching a git repository.
 set(PRE_CONFIGURE_FILE "git.cc.in")
 set(POST_CONFIGURE_FILE "${CMAKE_CURRENT_BINARY_DIR}/git.cpp")
-include(git_watcher.cmake)
+include(../git_watcher.cmake)
 
 # Create a library out of the compiled post-configure file.
 add_library(git STATIC ${POST_CONFIGURE_FILE})

--- a/better-example/git_watcher.cmake
+++ b/better-example/git_watcher.cmake
@@ -1,1 +1,0 @@
-../git_watcher.cmake

--- a/hello-world/CMakeLists.txt
+++ b/hello-world/CMakeLists.txt
@@ -5,7 +5,7 @@ project(HelloWorld)
 # the source code for watching a git repository.
 set(PRE_CONFIGURE_FILE "git.h.in")
 set(POST_CONFIGURE_FILE "git.h")
-include(git_watcher.cmake)
+include(../git_watcher.cmake)
 
 # Create a demo executable using a single source file that
 # prints the information baked into the "git.h" header.

--- a/hello-world/git_watcher.cmake
+++ b/hello-world/git_watcher.cmake
@@ -1,1 +1,0 @@
-../git_watcher.cmake

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -10,13 +10,15 @@ source $DIR/assert.sh
 #  https://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x
 create_temp_directory=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
 demo_src=$DIR/../hello-world
+git_watcher=$DIR/../git_watcher.cmake
 
 # Create a root directory and copy the demo code to there.
 root=$create_temp_directory
 src=$root/source
 build=$root/build
 mkdir -p $build
-cp -Lr $demo_src $src  # note -L flag to grab symlink content.
+cp -r $demo_src $src
+cp $git_watcher $src/..
 
 # Make sure we don't carry along a preconfigured git.h header.
 if [ -f src/git.h ]; then


### PR DESCRIPTION
Each of the example directories has a symlink to the root level `git_watcher.cmake` script.
This doesn't seem necessary, and it appears to break the examples on Windows.
This MR replaces those symlinks with a relative `include()`.