### PR TITLE
Reconfigure if the pre-configure file changes

### DIFF
--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -215,6 +215,14 @@ function(CheckGit _working_dir _state_changed)
     # the hash stored on-disk.
     HashGitState(state)
 
+    # Issue 14: post-configure file isn't being regenerated.
+    #
+    # Update the state to include the SHA256 for the pre-configure file.
+    # This forces the post-configure file to be regenerated if the
+    # pre-configure file has changed.
+    file(SHA256 ${PRE_CONFIGURE_FILE} preconfig_hash)
+    string(SHA256 state "${preconfig_hash}${state}")
+
     # Check if the state has changed compared to the backup on disk.
     if(EXISTS "${GIT_STATE_FILE}")
         file(READ "${GIT_STATE_FILE}" OLD_HEAD_CONTENTS)

--- a/tests/test_modified_preconfig_file.sh
+++ b/tests/test_modified_preconfig_file.sh
@@ -14,6 +14,11 @@ git init
 git add .
 git commit -am "Initial commit."
 
+# Make the state dirty, so that when we modify the
+# preconfigure file it doesn't regenerate just
+# because the git-state changed.
+echo "hello world" > dirty
+
 # Configure and build the project.
 set -e
 cd $build

--- a/tests/test_modified_preconfig_file.sh
+++ b/tests/test_modified_preconfig_file.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Purpose:
+# Test that items are regenerated after modifying the pre-configure
+# file. See issue 14.
+
+# Load utilities.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/util.sh
+
+# Create git history
+cd $src
+git init
+git add .
+git commit -am "Initial commit."
+
+# Configure and build the project.
+set -e
+cd $build
+cmake -G "$TEST_GENERATOR" $src
+cmake --build . --target demo
+
+# Record the date on the post-configure file, then
+# modify the pre-configure file.
+before=$(stat -c %y $src/git.h)
+echo "// this is a modification" >> "$src/git.h.in"
+
+# Make the project again. Verify that it regenerated
+# our git file.
+cmake --build . --target demo
+after=$(stat -c %y $src/git.h)
+
+# Modified stamps need to be different.
+if [ "$before" == "$after" ]; then
+    assert "1 -eq 0" $LINENO
+fi


### PR DESCRIPTION
This PR causes the input header to be reconfigured if the user changes it _without_ also changing any of the git history. There's also a unit test for verifying this behavior.

Closes #14.