### PR TITLE
add state for git describe

### DIFF
--- a/better-example/git.cc.in
+++ b/better-example/git.cc.in
@@ -24,3 +24,6 @@ std::string GitMetadata::CommitSubject() {
 std::string GitMetadata::CommitBody() {
     return @GIT_COMMIT_BODY@;
 }
+std::string GitMetadata::Describe() {
+    return "@GIT_DESCRIBE@";
+}

--- a/better-example/git.h
+++ b/better-example/git.h
@@ -24,4 +24,6 @@ public:
   static std::string CommitSubject();
   // The commit body.
   static std::string CommitBody();
+  // The commit describe.
+  static std::string Describe();
 };

--- a/better-example/main.cc
+++ b/better-example/main.cc
@@ -9,6 +9,7 @@ int main() {
             std::cerr << "WARN: there were uncommitted changes at build-time." << std::endl;
         }
         std::cout << "commit " << GitMetadata::CommitSHA1() << " (HEAD)\n"
+                  << "describe " << GitMetadata::Describe() << "\n"
                   << "Author: " << GitMetadata::AuthorName() << " <" << GitMetadata::AuthorEmail() << ">\n"
                   << "Date: " << GitMetadata::CommitDate() << "\n\n"
                   << GitMetadata::CommitSubject() << "\n" << GitMetadata::CommitBody() << std::endl;

--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -86,6 +86,7 @@ set(_state_variable_names
     GIT_COMMIT_DATE_ISO8601
     GIT_COMMIT_SUBJECT
     GIT_COMMIT_BODY
+    GIT_DESCRIBE
     # >>>
     # 1. Add the name of the additional git variable you're interested in monitoring
     #    to this list.
@@ -183,6 +184,14 @@ function(GetGitState _working_dir)
     #    "execute_process()" command. Be sure to set them in
     #    the environment using the same variable name you added
     #    to the "_state_variable_names" list.
+
+    # Get output of git describe
+    RunGitCommand(describe --always)
+    if(NOT exit_code EQUAL 0)
+        set(ENV{GIT_DESCRIBE} "false")
+    else()
+        set(ENV{GIT_DESCRIBE} "${output}")
+    endif()
 
 endfunction()
 


### PR DESCRIPTION
First of all, thank you for putting this excellent example onto github! 

With only a little time, I was able to modify it and make it do what I want, which is to use to get the output of ``git describe`` into my cmake and c++ code so I can have version information directly derived from the git commit used for the build. The intent of this pull request is probably identical to #5, which I did not see until I was ready to make this pull request. 

I am making this pull request with the hope of giving back to you for making this repo available. If you like the basic attempt but you want to make changes before merging, I will try to update the changes to meet your requirements. If you feel these changes are not in line with what you want in this repo, feel free to close and not merge this request.

Thanks!