### PR TITLE
Fix git commit body with semicolon

### DIFF
--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -164,10 +164,10 @@ function(GetGitState _working_dir)
     if(exit_code EQUAL 0)
         if(output)
             # Escape line breaks in the commit message.
-            string(REPLACE "\r\n" "\\r\\n\\\r\n" safe ${output})
+            string(REPLACE "\r\n" "\\r\\n\\\r\n" safe "${output}")
             if(safe STREQUAL output)
                 # Didn't have windows lines - try unix lines.
-                string(REPLACE "\n" "\\n\\\n" safe ${output})
+                string(REPLACE "\n" "\\n\\\n" safe "${output}")
             endif()
         else()
             # There was no commit body - set the safe string to empty.

--- a/tests/test_semicolon_multiline_commit_message.sh
+++ b/tests/test_semicolon_multiline_commit_message.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Purpose:
+# Test how the demo performs when a new commit is made.
+
+# Load utilities.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/util.sh
+
+# Create git history
+set -e
+cd $src
+git init
+git add .
+git commit -am 'Oh no!
+
+This spans multiple lines; with a semicolon.
+Can our script handle it?
+
+There should be a skipped above and after this line
+
+The End!'
+git log
+
+# Build the project
+set -e
+cd $build
+cmake -G "$TEST_GENERATOR" $src
+cmake --build . --target demo
+
+# Run the demo.
+# It should report EXIT_SUCCESS because git history was found.
+set +e
+./demo &> output.txt
+assert "$? -eq 0" $LINENO
+
+if ! grep -q "The End!" output.txt; then
+    echo "Dropped the last line"
+    assert "1 -eq 0" $LINENO
+fi
+


### PR DESCRIPTION
Use quotation marks around variable sent to `string` operation so that CMake interprets it as a string instead of a list so that we don't remove the semicolon.

See here for more details https://cmake.org/pipermail/cmake/2016-January/062594.html