### PR TITLE
Small tweaks to git describe; add unit test.

### DIFF
--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -183,19 +183,19 @@ function(GetGitState _working_dir)
         set(ENV{GIT_COMMIT_BODY} "\"\"") # empty string.
     endif()
 
+    # Get output of git describe
+    RunGitCommand(describe --always ${object})
+    if(NOT exit_code EQUAL 0)
+        set(ENV{GIT_DESCRIBE} "unknown")
+    else()
+        set(ENV{GIT_DESCRIBE} "${output}")
+    endif()
+
     # >>>
     # 2. Additional git properties can be added here via the
     #    "execute_process()" command. Be sure to set them in
     #    the environment using the same variable name you added
     #    to the "_state_variable_names" list.
-
-    # Get output of git describe
-    RunGitCommand(describe --always)
-    if(NOT exit_code EQUAL 0)
-        set(ENV{GIT_DESCRIBE} "false")
-    else()
-        set(ENV{GIT_DESCRIBE} "${output}")
-    endif()
 
 endfunction()
 

--- a/hello-world/git.h.in
+++ b/hello-world/git.h.in
@@ -24,3 +24,6 @@
 
 // The notes attached to the HEAD commit.
 #define GIT_COMMIT_BODY @GIT_COMMIT_BODY@
+
+// The output from git --describe (e.g. the most recent tag)
+#define GIT_DESCRIBE "@GIT_DESCRIBE@"

--- a/hello-world/main.cc
+++ b/hello-world/main.cc
@@ -11,6 +11,7 @@ int main() {
         // Print information about the commit.
         // The format imitates the output from "git log".
         std::cout << "\n\ncommit " << GIT_HEAD_SHA1 << " (HEAD)\n"
+                  << "Describe: " << GIT_DESCRIBE << "\n"
                   << "Author: " << GIT_AUTHOR_NAME << " <" << GIT_AUTHOR_EMAIL << ">\n"
                   << "Date: " << GIT_COMMIT_DATE_ISO8601 << "\n\n"
                   << GIT_COMMIT_SUBJECT << "\n" << GIT_COMMIT_BODY << std::endl;

--- a/tests/test_git_describe_with_tag.sh
+++ b/tests/test_git_describe_with_tag.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Purpose:
+# Test that git --describe reports a tag.
+
+# Load utilities.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/util.sh
+
+# Create git history
+set -e
+cd $src
+git init
+git add .
+git commit -am "Initial commit."
+echo "this is a new file" > some_file
+git add .
+git commit -am "Second commit."
+git tag -a v1.2 -m "version 1.2"
+echo "another file after the tag" > some_file_two
+git add .
+git commit -am "Third commit."
+
+
+# Build the project
+set -e
+cd $build
+cmake -G "$TEST_GENERATOR" $src
+cmake --build . --target demo
+
+# Run the demo.
+# It should report EXIT_SUCCESS because git history was found.
+set +e
+./demo &> output.txt
+assert "$? -eq 0" $LINENO
+
+# Check that the tag was printed
+set -e
+if ! grep -q "v1.2" output.txt; then
+    echo "Missing the version from describe."
+    assert "1 -eq 0" $LINENO
+fi


### PR DESCRIPTION
This PR makes a few modifications to #21, specifically:

1. Move the `git describe --always` down past the second chevron.
2. Add `GIT_DESCRIBE` to the C header.
3. A simple unit test to verify that tags are printed.