### PR TITLE
By default, check for non-zero exit codes from git command

### DIFF
--- a/tests/test_git_created_post_configure.sh
+++ b/tests/test_git_created_post_configure.sh
@@ -9,10 +9,20 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $DIR/util.sh
 
 # Configure and build the project.
+# Should fail because the git commands can't run.
 set -e
 cd build
 cmake -G "$TEST_GENERATOR" $src
+set +e
 cmake --build . --target demo
+assert "$? -ne 0" $LINENO
+set -e
+
+# Regenerate, but this time allow git commands to fail.
+# The build should pass.
+cmake -G "$TEST_GENERATOR" $src -DGIT_FAIL_IF_NONZERO_EXIT=FALSE
+cmake --build . --target demo
+assert "$? -eq 0" $LINENO
 
 # Run the demo.
 # It should report EXIT_FAILURE because no git history was found.

--- a/tests/test_no_git_history.sh
+++ b/tests/test_no_git_history.sh
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env bash
 #
 # Purpose:
@@ -8,13 +9,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $DIR/util.sh
 
 # Configure and build the project.
+# The build should fail because the git repo is missing.
 set -e
 cd build
 cmake -g "$TEST_GENERATOR" $src
-cmake --build . --target demo
-
-# Run the demo.
-# It should report EXIT_FAILURE because no git history was found.
 set +e
-./demo &> out_err.txt
-assert "$? -eq 1" $LINENO
+cmake --build . --target demo
+assert "$? -ne 1" $LINENO


### PR DESCRIPTION
This PR adds the optional `GIT_FAIL_IF_NONZERO_EXIT` variable. By default, the script will raise an error if any of the git commands return a non-zero exit code. This default behavior was chosen because it's easier to catch errors during build-time instead of run-time (e.g. "why is the commit SHA1 empty?").

Setting `GIT_FAIL_IF_NONZERO_EXIT=FALSE` disables this behavior -- the build will continue on its merry way if a git command fails.

Related to #26.

