### PR TITLE
Add option to ignore untracked files

### DIFF
--- a/tests/test_dirty_head_untracked.sh
+++ b/tests/test_dirty_head_untracked.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Purpose:
+# Test if the demo detects DIRTY in the presence of
+# untracked files. (PR #29)
+
+# Load utilities.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/util.sh
+
+# Create git history.
+# Note that there's an untracked file.
+set -e
+cd $src
+git init
+git add .
+git commit -am "Initial commit."
+echo "This is an untracked file!" >> untracked.txt
+
+# Build the project
+set -e
+cd $build
+cmake -G "$TEST_GENERATOR" $src
+cmake --build . --target demo
+
+# Run the demo.
+# It should report EXIT_SUCCESS because git history was found.
+set +e
+./demo &> output.txt
+assert "$? -eq 0" $LINENO
+
+# Check that the head is dirty (we have an untracked file).
+set -e
+if ! grep -q "uncommitted" output.txt; then
+    echo "Demo didn't reported a dirty head."
+    assert "1 -eq 0" $LINENO
+fi
+
+# Regenerate the build system but this time ignore
+# untracked changes.
+cmake -G "$TEST_GENERATOR" $src -DGIT_IGNORE_UNTRACKED=TRUE
+cmake --build . --target demo
+
+# Run the demo.
+set +e
+./demo &> output.txt
+assert "$? -eq 0" $LINENO
+
+# Check that demo reported that there were uncommitted changes.
+set -e
+if grep -q "uncommitted" output.txt; then
+    echo "Demo reported a dirty head, but we should have ignored untracked changes."
+    assert "1 -eq 0" $LINENO
+fi

--- a/tests/test_dirty_head_untracked.sh
+++ b/tests/test_dirty_head_untracked.sh
@@ -46,7 +46,8 @@ set +e
 ./demo &> output.txt
 assert "$? -eq 0" $LINENO
 
-# Check that demo reported that there were uncommitted changes.
+# Check that demo didn't report uncommitted changes- we're ignoring
+# the one untracked file.
 set -e
 if grep -q "uncommitted" output.txt; then
     echo "Demo reported a dirty head, but we should have ignored untracked changes."


### PR DESCRIPTION
Some people (like me) have untracked files in the repository which should be ignored by the **GIT_IS_DIRTY** variable. This PR adds a new option (called *GIT_IGNORE_UNTRACKED*) to enable that.