### PR TITLE
Use quotes consistently with GIT_COMMIT_BODY.

### DIFF
--- a/better-example/git.cc.in
+++ b/better-example/git.cc.in
@@ -22,7 +22,7 @@ std::string GitMetadata::CommitSubject() {
     return "@GIT_COMMIT_SUBJECT@";
 }
 std::string GitMetadata::CommitBody() {
-    return @GIT_COMMIT_BODY@;
+    return "@GIT_COMMIT_BODY@";
 }
 std::string GitMetadata::Describe() {
     return "@GIT_DESCRIBE@";

--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -208,9 +208,9 @@ function(GetGitState _working_dir)
             # There was no commit body - set the safe string to empty.
             set(safe "")
         endif()
-        set(ENV{GIT_COMMIT_BODY} "\"${safe}\"")
+        set(ENV{GIT_COMMIT_BODY} "${safe}")
     else()
-        set(ENV{GIT_COMMIT_BODY} "\"\"") # empty string.
+        set(ENV{GIT_COMMIT_BODY} "") # empty string.
     endif()
 
     # Get output of git describe

--- a/hello-world/git.h.in
+++ b/hello-world/git.h.in
@@ -23,7 +23,7 @@
 #define GIT_COMMIT_SUBJECT "@GIT_COMMIT_SUBJECT@"
 
 // The notes attached to the HEAD commit.
-#define GIT_COMMIT_BODY @GIT_COMMIT_BODY@
+#define GIT_COMMIT_BODY "@GIT_COMMIT_BODY@"
 
 // The output from git --describe (e.g. the most recent tag)
 #define GIT_DESCRIBE "@GIT_DESCRIBE@"


### PR DESCRIPTION
Closes #34.