### PR TITLE
Fix cmake max version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.2...3.27)
 project(cmake_git_version_tracking
     LANGUAGES C)
 


### PR DESCRIPTION
Newer versions of CMake have dropped comparability with scripts for CMake `< 3.5`.

By adding the `...3.27`, we tell CMake that the script with work with any CMake from 3.2 to 3.27, and it no longer errors with newer versions.