### PR TITLE
Add HEAD SHA1 shortened to 64 and 32 btis

### DIFF
--- a/git.c.in
+++ b/git.c.in
@@ -15,6 +15,12 @@ const char* git_AuthorEmail() {
 const char* git_CommitSHA1() {
     return "@GIT_HEAD_SHA1@";
 }
+uint32_t git_CommitSHA1_32(){
+    return 0x@GIT_HEAD_SHA1_32@U;
+}
+uint64_t git_CommitSHA1_64(){
+    return 0x@GIT_HEAD_SHA1_64@U;
+}
 const char* git_CommitDate() {
     return "@GIT_COMMIT_DATE_ISO8601@";
 }

--- a/git.h
+++ b/git.h
@@ -6,6 +6,7 @@
 // https://raw.githubusercontent.com/andrew-hardin/cmake-git-version-tracking/master/LICENSE
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 #define GIT_VERSION_TRACKING_EXTERN_C_BEGIN extern "C" {
@@ -36,6 +37,12 @@ const char* git_AuthorEmail();
 
 /// The commit SHA1.
 const char* git_CommitSHA1();
+
+/// Commit SHA1 shortened to 32 bits (eight characters)
+uint32_t git_CommitSHA1_32();
+
+/// Commit SHA1 shortened to 64 bits (sixteen characters)
+uint64_t git_CommitSHA1_64();
 
 /// The ISO8601 commit date.
 const char* git_CommitDate();
@@ -122,6 +129,12 @@ inline const StringOrView AuthorEmail() {
 inline const StringOrView CommitSHA1() {
   static const StringOrView kValue = internal::InitString(git_CommitSHA1());
   return kValue;
+}
+inline const uint32_t CommitSHA1_32() {
+    return git_CommitSHA1_32();
+}
+inline const uint64_t CommitSHA1_64() {
+    return git_CommitSHA1_64();
 }
 inline const StringOrView CommitDate() {
   static const StringOrView kValue = internal::InitString(git_CommitDate());

--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -97,6 +97,8 @@ CHECK_REQUIRED_VARIABLE(GIT_EXECUTABLE)
 set(_state_variable_names
     GIT_RETRIEVED_STATE
     GIT_HEAD_SHA1
+    GIT_HEAD_SHA1_32
+    GIT_HEAD_SHA1_64
     GIT_IS_DIRTY
     GIT_AUTHOR_NAME
     GIT_AUTHOR_EMAIL
@@ -176,6 +178,10 @@ function(GetGitState _working_dir)
     if(exit_code EQUAL 0)
         set(ENV{GIT_HEAD_SHA1} ${output})
     endif()
+    string(SUBSTRING ${output} 0 16 output)
+    set(ENV{GIT_HEAD_SHA1_64} ${output})
+    string(SUBSTRING ${output} 0 8 output)
+    set(ENV{GIT_HEAD_SHA1_32} ${output})
 
     RunGitCommand(show -s "--format=%an" ${object})
     if(exit_code EQUAL 0)


### PR DESCRIPTION
A shortened SHA is useful. Especially if it's short enough to store inside a 32 or 64 bit unsigned integer. This PR adds two variables which shorten the SHA to sixteen and eight characters, so that it fits in 64 and 32 bits respectively.

From my research, eight characters (32 bits) is enough to uniquely identify commits in most projects, and sixteen would likely be unique even for the Linux kernel.