### PR TITLE
CMake: bump required version to 3.10..3.31

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2...3.27)
+cmake_minimum_required(VERSION 3.10...3.31)
 project(cmake_git_version_tracking
     LANGUAGES C)
 


### PR DESCRIPTION
Hey, thank you for the awesome repository. I was wondering if you want to consider incrementing the required CMake versions.

Version numbers smaller than 3.10 have been deprecated since CMake 3.31 and version numbers smaller than 3.5 will produce an error with CMake 4.0.

See:
https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html