### PR TITLE
Implement the git short commit SHA1

### DIFF
--- a/git.c.in
+++ b/git.c.in
@@ -30,3 +30,6 @@ const char* git_Describe() {
 const char* git_Branch() {
     return "@GIT_BRANCH@";
 }
+const char* git_CommitShort() {
+    return "@GIT_SHORT@";
+}

--- a/git.h
+++ b/git.h
@@ -52,6 +52,9 @@ const char* git_Describe();
 /// The symbolic reference tied to HEAD.
 const char* git_Branch();
 
+/// The commit short SHA1.
+const char* git_CommitShort();
+
 GIT_VERSION_TRACKING_EXTERN_C_END
 #undef GIT_VERSION_TRACKING_EXTERN_C_BEGIN
 #undef GIT_VERSION_TRACKING_EXTERN_C_END
@@ -141,6 +144,10 @@ inline const StringOrView Describe() {
 }
 inline const StringOrView Branch() {
   static const StringOrView kValue = internal::InitString(git_Branch());
+  return kValue;
+}
+inline const StringOrView CommitShort() {
+  static const StringOrView kValue = internal::InitString(git_CommitShort());
   return kValue;
 }
 

--- a/git_watcher.cmake
+++ b/git_watcher.cmake
@@ -105,6 +105,7 @@ set(_state_variable_names
     GIT_COMMIT_BODY
     GIT_DESCRIBE
     GIT_BRANCH
+    GIT_SHORT
     # >>>
     # 1. Add the name of the additional git variable you're interested in monitoring
     #    to this list.
@@ -240,6 +241,14 @@ function(GetGitState _working_dir)
         set(ENV{GIT_BRANCH} "${object}")
     else()
         set(ENV{GIT_BRANCH} "${output}")
+    endif()
+
+    # Get output of git describe
+    RunGitCommand(rev-parse --short ${object})
+    if(NOT exit_code EQUAL 0)
+        set(ENV{GIT_SHORT} "unknown")
+    else()
+        set(ENV{GIT_SHORT} "${output}")
     endif()
 
     # >>>


### PR DESCRIPTION
Hi, thank you for your work. i thought it could be useful to allow users to get the short commit SHA1, for ergonomics. This is partially related to #49 , but instead of hard coding the length of the hash, we could leverage git ability to print a non ambiguous SHA1 prefix. Thanks